### PR TITLE
fix: closing a sync or file will set end_date without timezone

### DIFF
--- a/src/changeset/DAL/typeorm/changesetRepository.ts
+++ b/src/changeset/DAL/typeorm/changesetRepository.ts
@@ -104,7 +104,7 @@ export class ChangesetRepository extends Repository<ChangesetDb> implements ICha
       FROM ${schema}.entity
       WHERE changeset_id = ANY($1))
 
-    UPDATE ${schema}.file AS FILE SET status = 'completed', end_date = current_timestamp
+    UPDATE ${schema}.file AS FILE SET status = 'completed', end_date = LOCALTIMESTAMP
     FROM (
       SELECT file_id, COUNT(*) AS CompletedEntities
       FROM ${schema}.entity
@@ -123,7 +123,7 @@ export class ChangesetRepository extends Repository<ChangesetDb> implements ICha
       FROM ${schema}.entity
       WHERE changeset_id = ANY($1))
 
-    UPDATE ${schema}.sync AS sync_to_update SET status = 'completed', end_date = current_timestamp
+    UPDATE ${schema}.sync AS sync_to_update SET status = 'completed', end_date = LOCALTIMESTAMP
     FROM (
       SELECT DISTINCT sync_id
       FROM ${schema}.file
@@ -139,7 +139,7 @@ export class ChangesetRepository extends Repository<ChangesetDb> implements ICha
     transactionalEntityManager: EntityManager
   ): Promise<ReturningResult<ReturningId>> {
     return (await transactionalEntityManager.query(
-      `UPDATE ${schema}.sync AS sync_to_update SET status = 'completed', end_date = current_timestamp
+      `UPDATE ${schema}.sync AS sync_to_update SET status = 'completed', end_date = LOCALTIMESTAMP
     FROM (
       SELECT DISTINCT sync_id
       FROM ${schema}.file

--- a/src/file/DAL/typeorm/fileRepository.ts
+++ b/src/file/DAL/typeorm/fileRepository.ts
@@ -67,7 +67,7 @@ export class FileRepository extends Repository<FileDb> implements IFileRepositor
     transactionalEntityManager: EntityManager
   ): Promise<ReturningResult<ReturningId>> {
     return (await transactionalEntityManager.query(
-      `UPDATE ${schema}.file AS FILE SET status = 'completed', end_date = current_timestamp
+      `UPDATE ${schema}.file AS FILE SET status = 'completed', end_date = LOCALTIMESTAMP
     WHERE FILE.file_id = $1 AND FILE.total_entities = (SELECT COUNT(*) AS CompletedEntities
         FROM ${schema}.entity
         WHERE file_id = $1 AND (status = 'completed' OR status = 'not_synced'))
@@ -82,7 +82,7 @@ export class FileRepository extends Repository<FileDb> implements IFileRepositor
     transactionalEntityManager: EntityManager
   ): Promise<ReturningResult<ReturningId>> {
     return (await transactionalEntityManager.query(
-      `UPDATE ${schema}.sync AS sync_to_update SET status = 'completed', end_date = current_timestamp
+      `UPDATE ${schema}.sync AS sync_to_update SET status = 'completed', end_date = LOCALTIMESTAMP
     FROM (
       SELECT DISTINCT sync_id
       FROM ${schema}.file

--- a/src/sync/DAL/typeorm/syncRepository.ts
+++ b/src/sync/DAL/typeorm/syncRepository.ts
@@ -114,7 +114,7 @@ export class SyncRepository extends Repository<DbSync> implements ISyncRepositor
     return (await transactionalEntityManager.query(
       `
       UPDATE ${schema}.sync AS sync_to_update
-        SET status = 'completed', end_date = current_timestamp
+        SET status = 'completed', end_date = LOCALTIMESTAMP
         WHERE sync_to_update.id = $1
         AND sync_to_update.total_files = (
           SELECT COUNT(*) FROM osm_sync_tracker.file


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Closes #41 
