### PR TITLE
feat(sync): added option for rerunning not-synced entities on a rerun

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -203,6 +203,8 @@ paths:
                 startDate:
                   type: string
                   format: date-time
+                shouldRerunNotSynced:
+                  type: boolean
               required:
                 - rerunId
                 - startDate

--- a/src/sync/controllers/syncController.ts
+++ b/src/sync/controllers/syncController.ts
@@ -19,7 +19,7 @@ import { GeometryType } from '../../common/enums';
 type GetLatestSyncHandler = RequestHandler<undefined, BaseSync, undefined, { layerId: number; geometryType: GeometryType }>;
 type PostSyncHandler = RequestHandler<undefined, string, Sync>;
 type PatchSyncHandler = RequestHandler<{ syncId: string }, string, SyncUpdate>;
-type RerunSyncHandler = RequestHandler<{ syncId: string }, string, { rerunId: string; startDate: Date }>;
+type RerunSyncHandler = RequestHandler<{ syncId: string }, string, { rerunId: string; startDate: Date; shouldRerunNotSynced?: boolean }>;
 
 const txtplain = mime.contentType('text/plain') as string;
 
@@ -65,8 +65,9 @@ export class SyncController {
   };
 
   public rerunSync: RerunSyncHandler = async (req, res, next) => {
+    const { rerunId, startDate, shouldRerunNotSynced } = req.body;
     try {
-      const wasRerunCreated = await this.manager.rerunSyncIfNeeded(req.params.syncId, req.body.rerunId, req.body.startDate);
+      const wasRerunCreated = await this.manager.rerunSyncIfNeeded(req.params.syncId, rerunId, startDate, shouldRerunNotSynced);
       if (wasRerunCreated) {
         return res.status(httpStatus.CREATED).type(txtplain).send(httpStatus.getStatusText(httpStatus.CREATED));
       }

--- a/src/sync/models/sync.ts
+++ b/src/sync/models/sync.ts
@@ -29,3 +29,5 @@ export type BaseSync = Omit<Sync, 'baseSyncId' | 'runNumber'>;
 export type SyncUpdate = Omit<Partial<Sync>, 'id' | 'isFull'>;
 
 export type SyncWithReruns = Sync & { reruns: Sync[] };
+
+export type CreateRerunRequest = Sync & { shouldRerunNotSynced: boolean };

--- a/tests/integration/entity/entity.spec.ts
+++ b/tests/integration/entity/entity.spec.ts
@@ -79,7 +79,7 @@ describe('entity', function () {
         async function () {
           const syncForRerun = createStringifiedFakeSync();
           const file = createStringifiedFakeFile();
-          const rerunCreateBody = createStringifiedFakeRerunCreateBody();
+          const rerunCreateBody = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
           const entity1 = createStringifiedFakeEntity({ status: EntityStatus.COMPLETED });
           const entity2 = createStringifiedFakeEntity();
 

--- a/tests/integration/sync/helpers/generators.ts
+++ b/tests/integration/sync/helpers/generators.ts
@@ -30,5 +30,6 @@ export const createStringifiedFakeRerunCreateBody = (params: FakeStringifiedReru
   return {
     rerunId: params.rerunId ?? faker.datatype.uuid(),
     startDate: params.startDate ?? faker.datatype.datetime().toISOString(),
+    shouldRerunNotSynced: params.shouldRerunNotSynced ?? faker.datatype.boolean(),
   };
 };

--- a/tests/integration/sync/sync.spec.ts
+++ b/tests/integration/sync/sync.spec.ts
@@ -120,7 +120,7 @@ describe('sync', function () {
         async function () {
           const sync = createStringifiedFakeSync();
           const { id } = sync;
-          const rerunCreateBody = createStringifiedFakeRerunCreateBody();
+          const rerunCreateBody = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
 
           expect(await syncRequestSender.postSync(sync)).toHaveStatus(StatusCodes.CREATED);
           expect(await syncRequestSender.patchSync(id as string, { status: Status.FAILED })).toHaveStatus(StatusCodes.OK);
@@ -147,7 +147,7 @@ describe('sync', function () {
             isFull: true,
           });
           const { id } = sync;
-          const rerunCreateBody = createStringifiedFakeRerunCreateBody();
+          const rerunCreateBody = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
 
           expect(await syncRequestSender.postSync(sync)).toHaveStatus(StatusCodes.CREATED);
           expect(await syncRequestSender.patchSync(id as string, { status: Status.FAILED })).toHaveStatus(StatusCodes.OK);
@@ -163,6 +163,7 @@ describe('sync', function () {
         RERUN_TEST_TIMEOUT
       );
 
+      //should return 200 if the sync to rerun was successfully closed by trying to rerun
       it(
         'should return 200 if the sync to rerun was successfully closed by trying to rerun',
         async function () {
@@ -190,7 +191,7 @@ describe('sync', function () {
 
           expect(await syncRequestSender.patchSync(id as string, { status: Status.FAILED })).toHaveStatus(StatusCodes.OK);
 
-          const rerunCreateBody = createStringifiedFakeRerunCreateBody();
+          const rerunCreateBody = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
           const response = await syncRequestSender.rerunSync(id as string, rerunCreateBody);
 
           expect(response).toHaveProperty('status', StatusCodes.OK);
@@ -209,7 +210,7 @@ describe('sync', function () {
         'should complete a sync on the first rerun',
         async function () {
           // create the base sync
-          const baseSync = createStringifiedFakeSync({ totalFiles: 2 });
+          const baseSync = createStringifiedFakeSync({ isFull: false, totalFiles: 2 });
           expect(await syncRequestSender.postSync(baseSync)).toHaveStatus(StatusCodes.CREATED);
           const { id: baseSyncId } = baseSync;
 
@@ -235,7 +236,7 @@ describe('sync', function () {
 
           // mark the base sync as failure and rerun
           expect(await syncRequestSender.patchSync(baseSyncId as string, { status: Status.FAILED })).toHaveStatus(StatusCodes.OK);
-          const rerunCreateBody = createStringifiedFakeRerunCreateBody();
+          const rerunCreateBody = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
           const { rerunId } = rerunCreateBody;
           expect(await syncRequestSender.rerunSync(baseSyncId as string, rerunCreateBody)).toHaveStatus(httpStatus.CREATED);
 
@@ -356,7 +357,7 @@ describe('sync', function () {
           );
 
           // rerunning the sync while its is still in progress results in a conflict
-          const rerunCreateBody = createStringifiedFakeRerunCreateBody();
+          const rerunCreateBody = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
           const { rerunId: firstRerunId } = rerunCreateBody;
           expect(await syncRequestSender.rerunSync(baseSyncId as string, rerunCreateBody)).toHaveStatus(StatusCodes.CONFLICT);
 
@@ -477,7 +478,7 @@ describe('sync', function () {
           );
 
           // rerunning the sync while rerun is still in progress results in a conflict
-          const secondRerunCreateBody = createStringifiedFakeRerunCreateBody();
+          const secondRerunCreateBody = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
           const { rerunId: secondRerunId } = secondRerunCreateBody;
           expect(await syncRequestSender.rerunSync(baseSyncId as string, secondRerunCreateBody)).toHaveStatus(StatusCodes.CONFLICT);
 
@@ -581,7 +582,7 @@ describe('sync', function () {
           expect(latestSyncResponse.body).toMatchObject({ ...baseSync, status: Status.COMPLETED });
 
           // rerunning the sync when its completed will result in a conflict
-          const thirdRerunCreateBody = createStringifiedFakeRerunCreateBody();
+          const thirdRerunCreateBody = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
           expect(await syncRequestSender.rerunSync(baseSyncId as string, thirdRerunCreateBody)).toHaveStatus(StatusCodes.CONFLICT);
 
           // validate entity history count
@@ -601,7 +602,7 @@ describe('sync', function () {
 
           // mark the base sync as failure and rerun
           expect(await syncRequestSender.patchSync(baseSyncId as string, { status: Status.FAILED })).toHaveStatus(StatusCodes.OK);
-          const rerunCreateBody1 = createStringifiedFakeRerunCreateBody();
+          const rerunCreateBody1 = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
           const { rerunId: rerunId1 } = rerunCreateBody1;
           expect(await syncRequestSender.rerunSync(baseSyncId as string, rerunCreateBody1)).toHaveStatus(httpStatus.CREATED);
 
@@ -610,7 +611,7 @@ describe('sync', function () {
           expect(entityHistoryCount).toBe(0);
 
           expect(await syncRequestSender.patchSync(rerunId1 as string, { status: Status.FAILED })).toHaveStatus(StatusCodes.OK);
-          const rerunCreateBody2 = createStringifiedFakeRerunCreateBody();
+          const rerunCreateBody2 = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
           const { rerunId: rerunId2 } = rerunCreateBody2;
           expect(await syncRequestSender.rerunSync(baseSyncId as string, rerunCreateBody2)).toHaveStatus(httpStatus.CREATED);
 
@@ -619,7 +620,7 @@ describe('sync', function () {
           expect(entityHistoryCount).toBe(0);
 
           expect(await syncRequestSender.patchSync(rerunId2 as string, { status: Status.FAILED })).toHaveStatus(StatusCodes.OK);
-          const rerunCreateBody3 = createStringifiedFakeRerunCreateBody();
+          const rerunCreateBody3 = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
           const { rerunId: rerunId3 } = rerunCreateBody3;
           expect(await syncRequestSender.rerunSync(baseSyncId as string, rerunCreateBody3)).toHaveStatus(httpStatus.CREATED);
 
@@ -652,10 +653,210 @@ describe('sync', function () {
       );
 
       it(
+        'should complete a sync on a rerun with falsy shouldRerunNotSynced flag',
+        async function () {
+          // create the base sync
+          const baseSync = createStringifiedFakeSync({ isFull: false, totalFiles: 1 });
+          expect(await syncRequestSender.postSync(baseSync)).toHaveStatus(StatusCodes.CREATED);
+          const { id: baseSyncId } = baseSync;
+
+          // create file, failed and not synced entities and post them
+          const file = createStringifiedFakeFile({ totalEntities: 2 });
+          expect(await fileRequestSender.postFile(baseSyncId as string, file)).toHaveStatus(StatusCodes.CREATED);
+          const entity1 = createStringifiedFakeEntity({ status: EntityStatus.NOT_SYNCED });
+          const entity2 = createStringifiedFakeEntity({ status: EntityStatus.FAILED });
+          const file1Entities = [entity1, entity2];
+          expect(await entityRequestSender.postEntityBulk(file.fileId as string, file1Entities)).toHaveStatus(StatusCodes.CREATED);
+
+          // validate base sync is still in progress
+          expect(await syncRequestSender.getLatestSync(baseSync.layerId as number, baseSync.geometryType as GeometryType)).toHaveProperty(
+            'body.status',
+            Status.IN_PROGRESS
+          );
+
+          // mark the base sync as failure and rerun
+          expect(await syncRequestSender.patchSync(baseSyncId as string, { status: Status.FAILED })).toHaveStatus(StatusCodes.OK);
+          const rerunCreateBody = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: false });
+          const { rerunId } = rerunCreateBody;
+          expect(await syncRequestSender.rerunSync(baseSyncId as string, rerunCreateBody)).toHaveStatus(httpStatus.CREATED);
+
+          // validate expected entity history
+          const entity1History = await entityHistoryRepository.findOneBy({ entityId: entity1.entityId, fileId: file.fileId, syncId: baseSyncId });
+          expect(entity1History).toMatchObject({
+            ...entity1,
+            fileId: file.fileId,
+            changesetId: null,
+            status: EntityStatus.NOT_SYNCED,
+            syncId: baseSyncId,
+            baseSyncId: null,
+          });
+
+          const entity2History = await entityHistoryRepository.findOneBy({ entityId: entity2.entityId, fileId: file.fileId, syncId: baseSyncId });
+          expect(entity2History).toMatchObject({
+            ...entity2,
+            fileId: file.fileId,
+            changesetId: null,
+            status: EntityStatus.FAILED,
+            syncId: baseSyncId,
+            baseSyncId: null,
+          });
+
+          // the not_synced entity should remain not_synced
+          const fetchedEntity1 = await entityRepository.findOneBy({ entityId: entity1.entityId });
+          expect(fetchedEntity1).toMatchObject({
+            ...entity1,
+            status: EntityStatus.NOT_SYNCED,
+            changesetId: null,
+            fileId: file.fileId,
+            failReason: null,
+          });
+
+          // the failed entity should reset
+          const fetchedEntity2 = await entityRepository.findOneBy({ entityId: entity2.entityId });
+          expect(fetchedEntity2).toMatchObject({
+            ...entity2,
+            fileId: file.fileId,
+            status: EntityStatus.IN_RERUN,
+            changesetId: null,
+            action: null,
+            failReason: null,
+          });
+
+          // create changeset
+          const changeset = createStringifiedFakeChangeset();
+          expect(await changesetRequestSender.postChangeset(changeset)).toHaveStatus(StatusCodes.CREATED);
+
+          // post the file again for the rerun
+          expect(await fileRequestSender.postFile(rerunId as string, file)).toHaveStatus(StatusCodes.CREATED);
+
+          // set the failed entity in the file as completed and on the new changeset
+          const completedEntity2 = [{ ...entity2, status: EntityStatus.COMPLETED, changesetId: changeset.changesetId }];
+          expect(await entityRequestSender.postEntityBulk(file.fileId as string, completedEntity2)).toHaveStatus(StatusCodes.CREATED);
+
+          // close the changeset
+          expect(await changesetRequestSender.patchChangesetEntities(changeset.changesetId as string)).toHaveStatus(StatusCodes.OK);
+          const putChangesetsResponse = await changesetRequestSender.putChangesets([changeset.changesetId as string]);
+          expect(putChangesetsResponse).toHaveStatus(StatusCodes.OK);
+          expect(putChangesetsResponse.body).toMatchObject([baseSyncId]);
+
+          const latestSyncResponse = await syncRequestSender.getLatestSync(baseSync.layerId as number, baseSync.geometryType as GeometryType);
+          expect(latestSyncResponse.status).toBe(httpStatus.OK);
+          expect(latestSyncResponse.body).toMatchObject({ ...baseSync, status: Status.COMPLETED });
+
+          // validate entity history count
+          const entityHistoryCount = await entityHistoryRepository.countBy({ syncId: In([baseSyncId, rerunId]) });
+          expect(entityHistoryCount).toBe(2);
+        },
+        RERUN_TEST_TIMEOUT
+      );
+
+      it(
+        'should complete a sync on a rerun with falsy shouldRerunNotSynced flag where one file consisting only not synced',
+        async function () {
+          // create the base sync
+          const baseSync = createStringifiedFakeSync({ isFull: false, totalFiles: 2 });
+          expect(await syncRequestSender.postSync(baseSync)).toHaveStatus(StatusCodes.CREATED);
+          const { id: baseSyncId } = baseSync;
+
+          // create files
+          const file1 = createStringifiedFakeFile({ totalEntities: 1 });
+          expect(await fileRequestSender.postFile(baseSyncId as string, file1)).toHaveStatus(StatusCodes.CREATED);
+
+          const file2 = createStringifiedFakeFile({ totalEntities: 1 });
+          expect(await fileRequestSender.postFile(baseSyncId as string, file2)).toHaveStatus(StatusCodes.CREATED);
+
+          const entity1 = createStringifiedFakeEntity({ status: EntityStatus.NOT_SYNCED });
+          const entity2 = createStringifiedFakeEntity({ status: EntityStatus.FAILED });
+          expect(await entityRequestSender.postEntityBulk(file1.fileId as string, [entity1])).toHaveStatus(StatusCodes.CREATED);
+          expect(await entityRequestSender.postEntityBulk(file2.fileId as string, [entity2])).toHaveStatus(StatusCodes.CREATED);
+
+          // validate base sync is still in progress
+          expect(await syncRequestSender.getLatestSync(baseSync.layerId as number, baseSync.geometryType as GeometryType)).toHaveProperty(
+            'body.status',
+            Status.IN_PROGRESS
+          );
+
+          // mark the base sync as failure and rerun
+          expect(await syncRequestSender.patchSync(baseSyncId as string, { status: Status.FAILED })).toHaveStatus(StatusCodes.OK);
+          const rerunCreateBody = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: false });
+          const { rerunId } = rerunCreateBody;
+          expect(await syncRequestSender.rerunSync(baseSyncId as string, rerunCreateBody)).toHaveStatus(httpStatus.CREATED);
+
+          // validate expected entity history
+          const entity1History = await entityHistoryRepository.findOneBy({ entityId: entity1.entityId, fileId: file1.fileId, syncId: baseSyncId });
+          expect(entity1History).toMatchObject({
+            ...entity1,
+            fileId: file1.fileId,
+            changesetId: null,
+            status: EntityStatus.NOT_SYNCED,
+            syncId: baseSyncId,
+            baseSyncId: null,
+          });
+
+          const entity2History = await entityHistoryRepository.findOneBy({ entityId: entity2.entityId, fileId: file2.fileId, syncId: baseSyncId });
+          expect(entity2History).toMatchObject({
+            ...entity2,
+            fileId: file2.fileId,
+            changesetId: null,
+            status: EntityStatus.FAILED,
+            syncId: baseSyncId,
+            baseSyncId: null,
+          });
+
+          // the not_synced entity should remain not_synced
+          const fetchedEntity1 = await entityRepository.findOneBy({ entityId: entity1.entityId });
+          expect(fetchedEntity1).toMatchObject({
+            ...entity1,
+            status: EntityStatus.NOT_SYNCED,
+            changesetId: null,
+            fileId: file1.fileId,
+            failReason: null,
+          });
+
+          // the failed entity should reset
+          const fetchedEntity2 = await entityRepository.findOneBy({ entityId: entity2.entityId });
+          expect(fetchedEntity2).toMatchObject({
+            ...entity2,
+            fileId: file2.fileId,
+            status: EntityStatus.IN_RERUN,
+            changesetId: null,
+            action: null,
+            failReason: null,
+          });
+
+          // create changeset
+          const changeset = createStringifiedFakeChangeset();
+          expect(await changesetRequestSender.postChangeset(changeset)).toHaveStatus(StatusCodes.CREATED);
+
+          // post file2 again for the rerun
+          expect(await fileRequestSender.postFile(rerunId as string, file2)).toHaveStatus(StatusCodes.CREATED);
+
+          // set the failed entity in file2 as completed and on the new changeset
+          const completedEntity2 = [{ ...entity2, status: EntityStatus.COMPLETED, changesetId: changeset.changesetId }];
+          expect(await entityRequestSender.postEntityBulk(file2.fileId as string, completedEntity2)).toHaveStatus(StatusCodes.CREATED);
+
+          // close the changeset
+          expect(await changesetRequestSender.patchChangesetEntities(changeset.changesetId as string)).toHaveStatus(StatusCodes.OK);
+          const putChangesetsResponse = await changesetRequestSender.putChangesets([changeset.changesetId as string]);
+          expect(putChangesetsResponse).toHaveStatus(StatusCodes.OK);
+          expect(putChangesetsResponse.body).toMatchObject([baseSyncId]);
+
+          const latestSyncResponse = await syncRequestSender.getLatestSync(baseSync.layerId as number, baseSync.geometryType as GeometryType);
+          expect(latestSyncResponse.status).toBe(httpStatus.OK);
+          expect(latestSyncResponse.body).toMatchObject({ ...baseSync, status: Status.COMPLETED });
+
+          // validate entity history count
+          const entityHistoryCount = await entityHistoryRepository.countBy({ syncId: In([baseSyncId, rerunId]) });
+          expect(entityHistoryCount).toBe(2);
+        },
+        RERUN_TEST_TIMEOUT
+      );
+
+      it(
         'should on a rerun mark a file as in progress if it was completed while having not-synced entities',
         async function () {
           // create the base sync
-          const baseSync = createStringifiedFakeSync({ totalFiles: 2 });
+          const baseSync = createStringifiedFakeSync({ isFull: false, totalFiles: 2 });
           expect(await syncRequestSender.postSync(baseSync)).toHaveStatus(StatusCodes.CREATED);
           const { id: baseSyncId } = baseSync;
 
@@ -683,7 +884,7 @@ describe('sync', function () {
 
           // mark the base sync as failure and rerun
           expect(await syncRequestSender.patchSync(baseSyncId as string, { status: Status.FAILED })).toHaveStatus(StatusCodes.OK);
-          const firstRerunCreateBody = createStringifiedFakeRerunCreateBody();
+          const firstRerunCreateBody = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
           const { rerunId: firstRerunId } = firstRerunCreateBody;
           expect(await syncRequestSender.rerunSync(baseSyncId as string, firstRerunCreateBody)).toHaveStatus(httpStatus.CREATED);
 
@@ -729,7 +930,7 @@ describe('sync', function () {
 
           // mark the first rerun as failure and rerun again
           expect(await syncRequestSender.patchSync(firstRerunId as string, { status: Status.FAILED })).toHaveStatus(StatusCodes.OK);
-          const secondRerunCreateBody = createStringifiedFakeRerunCreateBody();
+          const secondRerunCreateBody = createStringifiedFakeRerunCreateBody({ shouldRerunNotSynced: true });
           const { rerunId: secondRerunId } = secondRerunCreateBody;
           expect(await syncRequestSender.rerunSync(baseSyncId as string, secondRerunCreateBody)).toHaveStatus(httpStatus.CREATED);
 

--- a/tests/integration/sync/types.ts
+++ b/tests/integration/sync/types.ts
@@ -2,4 +2,4 @@ import { Sync } from '../../../src/sync/models/sync';
 
 export type StringifiedSync = Partial<Omit<Sync, 'startDate' | 'endDate' | 'dumpDate'>> & { startDate?: string; endDate?: string; dumpDate?: string };
 
-export type StringifiedRerunCreateBody = Partial<{ rerunId: string; startDate: string }>;
+export type StringifiedRerunCreateBody = Partial<{ rerunId: string; startDate: string; shouldRerunNotSynced: boolean }>;


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✔                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |
