### PR TITLE
ci: docker release tag missing vector prefix

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -19,13 +19,13 @@ permissions:
 
 jobs:
   build_and_push_docker:
-    uses: MapColonies/shared-workflows/.github/workflows/build-and-push-docker.yaml@v2
+    uses: MapColonies/shared-workflows/.github/workflows/build-and-push-docker.yaml@v4
     secrets: inherit
     with:
       scope: vector
 
   build_and_push_helm:
-    uses: MapColonies/shared-workflows/.github/workflows/build-and-push-helm.yaml@v2
+    uses: MapColonies/shared-workflows/.github/workflows/build-and-push-helm.yaml@v4
     secrets: inherit
     with:
       scope: vector


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✔  |
| New feature     | ✖  |
| Breaking change | ✖  |
| Deprecations    | ✖  |
| Documentation   | ✖  |
| Tests added     | ✖  |
| Chore           | ✖  |

Further information:
This PR should fix the docker tag release to add vector/ prefix before pushing the image to the registry. 